### PR TITLE
👷ci(deploy): 更新部署工作流中的目标路径

### DIFF
--- a/.github/workflows/automaticDeploy.yml
+++ b/.github/workflows/automaticDeploy.yml
@@ -35,4 +35,4 @@ jobs:
                   # 用户
                   REMOTE_USER: 'root'
                   # 目标地址
-                  TARGET: '/www/wwwroot/firstHonoApi/src'
+                  TARGET: '/opt/1panel/apps/openresty/openresty/www/sever/src'


### PR DESCRIPTION
- 将自动部署工作流中的 TARGET 变量从 '/www/wwwroot/firstHonoApi/src' 修改为 '/opt/1panel/apps/openresty/openresty/www/sever/src'